### PR TITLE
caffe for pi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,10 @@ ifeq ($(ALLOW_LMDB_NOLOCK), 1)
 endif
 endif
 
+ifeq ($(USE_RASPI3),1)
+	COMMON_FLAGS += -mfpu=neon-vfpv4 -funsafe-math-optimizations -ftree-vectorize -fomit-frame-pointer -mcpu=cortex-a53
+endif
+
 # CPU-only configuration
 ifeq ($(CPU_ONLY), 1)
 	OBJS := $(PROTO_OBJS) $(CXX_OBJS)

--- a/Makefile.config.cpu
+++ b/Makefile.config.cpu
@@ -62,7 +62,7 @@ PYTHON_LIB := /usr/lib
 # PYTHON_LIB := $(ANACONDA_HOME)/lib
 
 INCLUDE_HDF5 := /usr/include/hdf5/serial
-LIBRARY_HDF5 := /usr/lib/x86_64-linux-gnu/hdf5/serial
+LIBRARY_HDF5 := /usr/lib/arm-linux-gnueabihf/hdf5/serial
 
 # When compiling next to TF, need to sync the protobuf version
 INCLUDE_TF_PROTOBUF := ../../../protobuf/include

--- a/Makefile.config.gpu.cudnn
+++ b/Makefile.config.gpu.cudnn
@@ -60,7 +60,7 @@ PYTHON_LIB := /usr/lib
 # PYTHON_LIB := $(ANACONDA_HOME)/lib
 
 INCLUDE_HDF5 := /usr/include/hdf5/serial
-LIBRARY_HDF5 := /usr/lib/x86_64-linux-gnu/hdf5/serial
+LIBRARY_HDF5 := /usr/lib/arm-linux-gnueabihf/hdf5/serial
 
 # When compiling next to TF, need to sync the protobuf version
 INCLUDE_TF_PROTOBUF := ../../../protobuf/include

--- a/Makefile.config.pi3
+++ b/Makefile.config.pi3
@@ -6,16 +6,17 @@
 
 USE_OPENCV := 1
 USE_LMDB := 1
+USE_RASPI3 := 1
 
 # CPU-only switch (uncomment to build without GPU support).
-# CPU_ONLY := 1
+CPU_ONLY := 1
 
 # To customize your choice of compiler, uncomment and set the following.
 # N.B. the default for Linux is g++ and the default for OSX is clang++
 #CUSTOM_CXX := g++
 
 # CUDA directory contains bin/ and lib/ directories that we need.
-CUDA_DIR := /usr/local/cuda
+#CUDA_DIR := /usr/local/cuda
 # On Ubuntu 14.04, if cuda tools are installed via
 # "sudo apt-get install nvidia-cuda-toolkit" then use this instead:
 # CUDA_DIR := /usr
@@ -23,10 +24,12 @@ CUDA_DIR := /usr/local/cuda
 # CUDA architecture setting: going with all of them (up to CUDA 5.5 compatible).
 # For the latest architecture, you need to install CUDA >= 6.0 and uncomment
 # the *_50 lines below.
-CUDA_ARCH := -gencode arch=compute_30,code=sm_30 \
-		-gencode arch=compute_35,code=sm_35 \
-		-gencode arch=compute_50,code=sm_50 \
-		-gencode arch=compute_52,code=sm_52 
+#CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
+#		-gencode arch=compute_20,code=sm_21 \
+#		-gencode arch=compute_30,code=sm_30 \
+#		-gencode arch=compute_35,code=sm_35 \
+		#-gencode arch=compute_50,code=sm_50 \
+		#-gencode arch=compute_50,code=compute_50
 
 # BLAS choice:
 # atlas for ATLAS (default)

--- a/docs/tutorial/interfaces.md
+++ b/docs/tutorial/interfaces.md
@@ -100,7 +100,7 @@ Build MatCaffe with `make all matcaffe`. After that, you may test it using `make
 Common issue: if you run into error messages like `libstdc++.so.6:version 'GLIBCXX_3.4.15' not found` during `make mattest`, then it usually means that your Matlab's runtime libraries do not match your compile-time libraries. You may need to do the following before you start Matlab:
 
     export LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:/usr/local/cuda/lib64
-    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+    export LD_PRELOAD=/usr/lib/arm-linux-gnueabihf/libstdc++.so.6
 
 Or the equivalent based on where things are installed on your system, and do `make mattest` again to see if the issue is fixed. Note: this issue is sometimes more complicated since during its startup Matlab may overwrite your `LD_LIBRARY_PATH` environment variable. You can run `!ldd ./matlab/+caffe/private/caffe_.mexa64` (the mex extension may differ on your system) in Matlab to see its runtime libraries, and preload your compile-time libraries by exporting them to your `LD_PRELOAD` environment variable.
 

--- a/matlab/demo/classification_demo.m
+++ b/matlab/demo/classification_demo.m
@@ -22,7 +22,7 @@ function [scores, maxlabel] = classification_demo(im, use_gpu)
 %
 % You may need to do the following before you start matlab:
 %  $ export LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:/usr/local/cuda-5.5/lib64
-%  $ export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+%  $ export LD_PRELOAD=/usr/lib/arm-linux-gnueabihf/libstdc++.so.6
 % Or the equivalent based on where things are installed on your system
 %
 % Usage:


### PR DESCRIPTION
Change all hard coded path from "x86_64-linux-gnu" to "arm-linux-gnueabihf" 
to work with raspberrpi 3 on Raspbian Jessie 