### PR TITLE
roipool layer without spatial scale 

### DIFF
--- a/include/caffe/layers/roi_pooling_layer.hpp
+++ b/include/caffe/layers/roi_pooling_layer.hpp
@@ -76,6 +76,8 @@ class ROIPoolingLayer : public Layer<Dtype> {
   int pooled_height_;
   int pooled_width_;
   Dtype spatial_scale_;
+  Dtype spatial_scale_h_;
+  Dtype spatial_scale_w_;
   Blob<int> max_idx_;
 };
 

--- a/src/caffe/layers/roi_pooling_layer.cpp
+++ b/src/caffe/layers/roi_pooling_layer.cpp
@@ -22,7 +22,19 @@ void ROIPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   pooled_height_ = roi_pool_param.pooled_h();
   pooled_width_ = roi_pool_param.pooled_w();
   spatial_scale_ = roi_pool_param.spatial_scale();
+  if (spatial_scale_ < 0)
+    {
+      spatial_scale_h_ = bottom[0]->height();
+      spatial_scale_w_ = bottom[0]->width();
+    }
+  else
+    {
+      spatial_scale_w_ = spatial_scale_;
+      spatial_scale_h_ = spatial_scale_;
+    }
   LOG(INFO) << "Spatial scale: " << spatial_scale_;
+  LOG(INFO) << "Spatial scale (h): " << spatial_scale_h_;
+  LOG(INFO) << "Spatial scale (w): " << spatial_scale_w_;
 }
 
 template <typename Dtype>
@@ -54,10 +66,10 @@ void ROIPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   // For each ROI R = [batch_index x1 y1 x2 y2]: max pool over R
   for (int n = 0; n < num_rois; ++n) {
     int roi_batch_ind = bottom_rois[0];
-    int roi_start_w = round(bottom_rois[1] * spatial_scale_);
-    int roi_start_h = round(bottom_rois[2] * spatial_scale_);
-    int roi_end_w = round(bottom_rois[3] * spatial_scale_);
-    int roi_end_h = round(bottom_rois[4] * spatial_scale_);
+    int roi_start_w = round(bottom_rois[1] * spatial_scale_w_);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale_h_);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale_w_);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale_h_);
     CHECK_GE(roi_batch_ind, 0);
     CHECK_LT(roi_batch_ind, batch_size);
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1692,7 +1692,12 @@ message ROIPoolingParameter {
   optional uint32 pooled_w = 2 [default = 0]; // The pooled output width
   // Multiplicative spatial scale factor to translate ROI coords from their
   // input scale to the scale used when pooling
-  optional float spatial_scale = 3 [default = 1];
+  // in convientional roi_pooling it is done in original img, coordinates are given in absolute pixels
+  // and so spatial_scale should be 1
+  // in deepdetect case, coordinates are relative in [0,1]^2 and so spatial scale should be
+  // the h,w of input 'blob', -1 (any negative value)
+  // computes it dynamically from input blob
+  optional float spatial_scale = 3 [default = -1];
 }
 
 message ScaleParameter {


### PR DESCRIPTION
autocompute scale factor from input blob size if scale factor is not given , or given <0 (which is now the default)  (assumes coordinates of boxes are in [0,1]²) + allow non-squared input blob h,w